### PR TITLE
feat: deserialize BinTree and HashmapE into extendable types

### DIFF
--- a/crates/tlb-ton/src/bin_tree/mod.rs
+++ b/crates/tlb-ton/src/bin_tree/mod.rs
@@ -75,7 +75,7 @@ where
 
 impl<'de, T, As, C> CellDeserializeAsWithArgs<'de, C> for BinTree<As>
 where
-    C: IntoIterator<Item=T> + Extend<T> + Default, // IntoIterator used as type constraint for T
+    C: IntoIterator<Item = T> + Extend<T> + Default, // IntoIterator used as type constraint for T
     As: CellDeserializeAsWithArgs<'de, T>,
     As::Args: Clone,
 {
@@ -127,8 +127,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
     use super::BinTree;
+    use std::collections::BTreeSet;
     use tlb::bits::bitvec::bits;
     use tlb::bits::bitvec::order::Msb0;
     use tlb::r#as::{Data, NoArgs, Ref, Same};

--- a/crates/tlb-ton/src/hashmap/aug.rs
+++ b/crates/tlb-ton/src/hashmap/aug.rs
@@ -1,4 +1,5 @@
 use std::iter::once;
+
 use impl_tools::autoimpl;
 use tlb::{
     bits::{
@@ -242,10 +243,10 @@ where
 }
 
 impl<'de, T, As, C> CellDeserializeAsWithArgs<'de, C> for HashmapE<As>
-    where
-        C: IntoIterator<Item=(Key, T)> + Extend<(Key, T)> + Default, // IntoIterator used as type constraint for T
-        As: CellDeserializeAsWithArgs<'de, T>,
-        As::Args: Clone,
+where
+    C: IntoIterator<Item = (Key, T)> + Extend<(Key, T)> + Default, // IntoIterator used as type constraint for T
+    As: CellDeserializeAsWithArgs<'de, T>,
+    As::Args: Clone,
 {
     // (n, As::Args)
     type Args = (u32, As::Args);
@@ -443,10 +444,10 @@ where
 
 pub type Key = BitVec<u8, Msb0>;
 impl<'de, T, As, C> CellDeserializeAsWithArgs<'de, C> for Hashmap<As, ()>
-    where
-        C: IntoIterator<Item=(Key, T)> + Extend<(Key, T)> + Default, // IntoIterator used as type constraint for T
-        As: CellDeserializeAsWithArgs<'de, T>,
-        As::Args: Clone
+where
+    C: IntoIterator<Item = (Key, T)> + Extend<(Key, T)> + Default, // IntoIterator used as type constraint for T
+    As: CellDeserializeAsWithArgs<'de, T>,
+    As::Args: Clone,
 {
     /// (n, As::Args)
     type Args = (u32, As::Args);
@@ -468,12 +469,13 @@ impl<'de, T, As, C> CellDeserializeAsWithArgs<'de, C> for Hashmap<As, ()>
             mut prefix: Key,
             args: As::Args,
         ) -> Result<(), CellParserError<'de>>
-            where
-                C: Extend<(Key, T)>,
-                As: CellDeserializeAsWithArgs<'de, T>,
+        where
+            C: Extend<(Key, T)>,
+            As: CellDeserializeAsWithArgs<'de, T>,
         {
             // label:(HmLabel ~l n)
-            let next_prefix: BitVec<u8, Msb0> = parser.unpack_as_with::<_, HmLabel>(n).context("label")?;
+            let next_prefix: BitVec<u8, Msb0> =
+                parser.unpack_as_with::<_, HmLabel>(n).context("label")?;
             // {n = (~m) + l}
             let m = n - next_prefix.len() as u32;
 
@@ -502,10 +504,24 @@ impl<'de, T, As, C> CellDeserializeAsWithArgs<'de, C> for Hashmap<As, ()>
             Ok(())
         }
 
-        parse::<_, As, C>(parser, &mut stack, &mut output, n, Key::default(), args.clone())?;
+        parse::<_, As, C>(
+            parser,
+            &mut stack,
+            &mut output,
+            n,
+            Key::default(),
+            args.clone(),
+        )?;
 
         while let Some((n, prefix, mut parser)) = stack.pop() {
-            parse::<_, As, C>(&mut parser, &mut stack, &mut output, n, prefix, args.clone())?;
+            parse::<_, As, C>(
+                &mut parser,
+                &mut stack,
+                &mut output,
+                n,
+                prefix,
+                args.clone(),
+            )?;
         }
 
         Ok(output)
@@ -770,7 +786,6 @@ mod tests {
         // 128 -> 777
         assert_eq!(hm.get(128u8.to_be_bytes().as_bits()), Some(&777));
     }
-
 
     #[test]
     fn hashmape_parse_as_std_btreemap() {

--- a/crates/tlb-ton/src/hashmap/aug.rs
+++ b/crates/tlb-ton/src/hashmap/aug.rs
@@ -491,7 +491,7 @@ impl<'de, T, As, C> CellDeserializeAsWithArgs<'de, C> for Hashmap<As, ()>
                         // HashmapNode (n + 1)
                         .map(|(next_prefix, parser)| {
                             let mut prefix = prefix.clone();
-                            prefix.push(if next_prefix == 0 { false } else { true });
+                            prefix.push(next_prefix != 0);
 
                             (m - 1, prefix, parser)
                         })

--- a/crates/tlb-ton/src/lib.rs
+++ b/crates/tlb-ton/src/lib.rs
@@ -1,11 +1,11 @@
+mod address;
 pub mod bin_tree;
+mod boc;
 pub mod currency;
 pub mod hashmap;
-mod address;
-mod boc;
 mod message;
 mod state_init;
 mod timestamp;
 mod unary;
 
-pub use self::{address::*, boc::*, message::*, state_init::*, timestamp::*, unary::*,};
+pub use self::{address::*, boc::*, message::*, state_init::*, timestamp::*, unary::*};


### PR DESCRIPTION
This PR contains the implementation of deserialization as `C: IntoIterator<Item = T> + Extend<T> + Default` for `HashmapE<T, ()>` and `BinTree`.
Please take a look and contact me if you have any questions.

`cargo fmt` rewrote the entire `bin_tree.rs` file for some reason, sorry about that.