### PR TITLE
fix: convert bits to bytes in Remainder adapter for byte-oriented types

### DIFF
--- a/crates/bits/src/as/remainder.rs
+++ b/crates/bits/src/as/remainder.rs
@@ -45,7 +45,7 @@ impl<'de: 'a, 'a> BitUnpackAs<'de, Cow<'a, [u8]>> for Remainder {
     where
         R: BitReader<'de> + ?Sized,
     {
-        let n = reader.bits_left();
+        let n = reader.bits_left() / 8;
         reader.unpack_as::<_, BorrowCow>(n)
     }
 }
@@ -70,7 +70,7 @@ impl<'de: 'a, 'a> BitUnpackAs<'de, Cow<'a, str>> for Remainder {
     where
         R: BitReader<'de> + ?Sized,
     {
-        let n = reader.bits_left();
+        let n = reader.bits_left() / 8;
         reader.unpack_as::<_, BorrowCow>(n)
     }
 }
@@ -84,5 +84,37 @@ impl<'de> BitUnpackAs<'de, String> for Remainder {
         R: BitReader<'de> + ?Sized,
     {
         reader.unpack_as::<Cow<str>, Self>(()).map(Cow::into_owned)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitvec::{bits, order::Msb0, vec::BitVec};
+
+    use crate::de::{unpack_as, unpack_fully_as};
+
+    use super::Remainder;
+
+    #[test]
+    fn remainder_bytes() {
+        let input: &[u8] = &[0xDE, 0xAD, 0xBE, 0xEF];
+        let bits = BitVec::<u8, Msb0>::from_slice(input);
+        let result: Vec<u8> = unpack_fully_as::<_, Remainder>(&bits, ()).unwrap();
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn remainder_string() {
+        let input = "hello";
+        let bits = BitVec::<u8, Msb0>::from_slice(input.as_bytes());
+        let result: String = unpack_fully_as::<_, Remainder>(&bits, ()).unwrap();
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn remainder_bitvec() {
+        let bits = bits![u8, Msb0; 1, 0, 1, 1, 0];
+        let result: BitVec<u8, Msb0> = unpack_as::<_, Remainder>(bits, ()).unwrap();
+        assert_eq!(result, bits);
     }
 }


### PR DESCRIPTION
Remainder's BitUnpackAs impls for Cow<[u8]> and Cow<str> were passing bits_left() directly to BorrowCow, which expects the length in bytes. This caused it to attempt reading bits*8 bits, resulting in an EOF error.

Divide bits_left() by 8 for these byte-oriented types. The BitSlice impl is unaffected since BorrowCow for BitSlice correctly expects bits.

Discovered while using `ton-contracts::jetton::JettonTransfer::parse` on a real transaction with a TEP-74 text comment in the `forward_payload` field. The `ForwardPayloadComment::unpack` path calls `Remainder` to read the comment text as `String`, which hits this bug.